### PR TITLE
[FEATURE] In local redirects: use NtProtectVirtualMemory. Do not allo…

### DIFF
--- a/libpeconv/include/peconv/hooks.h
+++ b/libpeconv/include/peconv/hooks.h
@@ -34,33 +34,9 @@ namespace peconv {
             }
         }
 
-        bool makeBackup(BYTE *patch_ptr, size_t patch_size)
-        {
-            if (!patch_ptr) {
-                return false;
-            }
-            deleteBackup();
-            this->sourcePtr = patch_ptr;
-            this->buffer = new BYTE[patch_size];
-            this->bufferSize = patch_size;
+        bool makeBackup(BYTE *patch_ptr, size_t patch_size);
 
-            memcpy(buffer, patch_ptr, patch_size);
-            return true;
-        }
-
-        bool applyBackup()
-        {
-            if (!isBackup()) {
-                return false;
-            }
-            DWORD oldProtect = 0;
-            if (!VirtualProtect((LPVOID)sourcePtr, bufferSize, PAGE_EXECUTE_READWRITE, &oldProtect)) {
-                return false;
-            }
-            memcpy(sourcePtr, buffer, bufferSize);
-            VirtualProtect((LPVOID)sourcePtr, bufferSize, oldProtect, &oldProtect);
-            return true;
-        }
+        bool applyBackup();
 
         bool isBackup()
         {
@@ -106,14 +82,22 @@ namespace peconv {
     };
 
     /**
-    Installs inline hook at the given ptr. Returns the number of bytes overwriten. 64 bit version.
+    Installs inline hook at the given ptr. Returns the number of bytes overwriten.
+    64 bit version.
     */
     size_t redirect_to_local64(void *ptr, ULONGLONG new_offset, PatchBackup* backup = nullptr);
 
     /**
-    Installs inline hook at the given ptr. Returns the number of bytes overwriten. 32 bit version.
+    Installs inline hook at the given ptr. Returns the number of bytes overwriten.
+    32 bit version.
     */
     size_t redirect_to_local32(void *ptr, DWORD new_offset, PatchBackup* backup = nullptr);
+
+    /**
+    Installs inline hook at the given ptr. Returns the number of bytes overwriten.
+    Uses bitness of the current applications for the bitness of the intalled hook.
+    */
+    size_t redirect_to_local(void *ptr, void* new_function_ptr, PatchBackup* backup = nullptr);
 
     /**
     Replaces a target address of JMP <DWORD> or CALL <DWORD>

--- a/libpeconv/src/hooks.cpp
+++ b/libpeconv/src/hooks.cpp
@@ -1,6 +1,75 @@
 #include "peconv\hooks.h"
+#include "peconv.h"
 
 using namespace peconv;
+
+namespace peconv {
+
+    bool is_pointer_in_ntdll(LPVOID lpAddress)
+    {
+        HMODULE mod = GetModuleHandle("ntdll.dll");
+        size_t module_size = peconv::get_image_size((BYTE*)mod);
+        if (peconv::validate_ptr(mod, module_size, lpAddress, sizeof(BYTE))) {
+            return true; //this address lies within NTDLL
+        }
+        return false;
+    }
+
+    BOOL nt_protect(LPVOID lpAddress, SIZE_T dwSize, DWORD flNewProtect, PDWORD lpflOldProtect)
+    {
+        FARPROC proc = GetProcAddress(GetModuleHandle("ntdll.dll"), "NtProtectVirtualMemory");
+        if (!proc) {
+            return FALSE;
+        }
+        NTSTATUS(NTAPI *_NtProtectVirtualMemory)(
+            IN HANDLE,
+            IN OUT PVOID*,
+            IN OUT PSIZE_T,
+            IN DWORD,
+            OUT PDWORD) =
+            (NTSTATUS(NTAPI *)(
+                IN HANDLE,
+                IN OUT PVOID*,
+                IN OUT PSIZE_T,
+                IN DWORD,
+                OUT PDWORD)) proc;
+
+        SIZE_T protect_size = dwSize;
+        NTSTATUS status = _NtProtectVirtualMemory(GetCurrentProcess(), &lpAddress, &protect_size, flNewProtect, lpflOldProtect);
+        if (status != S_OK) {
+            return FALSE;
+        }
+        return TRUE;
+    }
+};
+
+bool PatchBackup::makeBackup(BYTE *patch_ptr, size_t patch_size)
+{
+    if (!patch_ptr) {
+        return false;
+    }
+    deleteBackup();
+    this->sourcePtr = patch_ptr;
+    this->buffer = new BYTE[patch_size];
+    this->bufferSize = patch_size;
+
+    memcpy(buffer, patch_ptr, patch_size);
+    return true;
+}
+
+bool PatchBackup::applyBackup()
+{
+    if (!isBackup()) {
+        return false;
+    }
+    DWORD oldProtect = 0;
+    if (!nt_protect((LPVOID)sourcePtr, bufferSize, PAGE_EXECUTE_READWRITE, &oldProtect)) {
+        return false;
+    }
+    memcpy(sourcePtr, buffer, bufferSize);
+    nt_protect((LPVOID)sourcePtr, bufferSize, oldProtect, &oldProtect);
+    return true;
+}
 
 FARPROC peconv::hooking_func_resolver::resolve_func(LPSTR lib_name, LPSTR func_name)
 {
@@ -27,11 +96,12 @@ size_t peconv::redirect_to_local64(void *ptr, ULONGLONG new_offset, PatchBackup*
         0xFF, 0xE0 //jmp rax
     };
     const size_t hook64_size = sizeof(hook_64);
-    if (ptr == VirtualProtect) {
-        return 0; //do not allow to hook VirtualProtect
+    if (is_pointer_in_ntdll(ptr)) {
+        std::cout << "[WARNING] Patching NTDLL is not allowed because of possible stability issues!\n";
+        return 0;
     }
     DWORD oldProtect = 0;
-    if (!VirtualProtect((LPVOID)ptr,
+    if (!nt_protect((LPVOID)ptr,
         hook64_size,
         PAGE_EXECUTE_READWRITE, //this must be executable if we are hooking kernel32.dll, because we are using VirtualProtect from kernel32 at the same time
         &oldProtect))
@@ -45,7 +115,7 @@ size_t peconv::redirect_to_local64(void *ptr, ULONGLONG new_offset, PatchBackup*
     memcpy(hook_64 + 2, &new_offset, sizeof(ULONGLONG));
     memcpy(ptr, hook_64, hook64_size);
 
-    VirtualProtect((LPVOID)ptr, hook64_size, oldProtect, &oldProtect);
+    nt_protect((LPVOID)ptr, hook64_size, oldProtect, &oldProtect);
     return hook64_size;
 }
 
@@ -58,11 +128,12 @@ size_t peconv::redirect_to_local32(void *ptr, DWORD new_offset, PatchBackup* bac
         0xFF, 0xE0 //jmp eax
     };
     const size_t hook32_size = sizeof(hook_32);
-    if (ptr == VirtualProtect) {
-        return 0; //do not allow to hook VirtualProtect
+    if (is_pointer_in_ntdll(ptr)) {
+        std::cout << "[WARNING] Patching NTDLL is not allowed because of possible stability issues!\n";
+        return 0;
     }
     DWORD oldProtect = 0;
-    if (!VirtualProtect((LPVOID)ptr,
+    if (!nt_protect((LPVOID)ptr,
         hook32_size,
         PAGE_EXECUTE_READWRITE, //this must be executable if we are hooking kernel32.dll, because we are using VirtualProtect from kernel32 at the same time
         &oldProtect))
@@ -76,8 +147,17 @@ size_t peconv::redirect_to_local32(void *ptr, DWORD new_offset, PatchBackup* bac
     memcpy(hook_32 + 1, &new_offset, sizeof(DWORD));
     memcpy(ptr, hook_32, hook32_size);
 
-    VirtualProtect((LPVOID)ptr, hook32_size, oldProtect, &oldProtect);
+    nt_protect((LPVOID)ptr, hook32_size, oldProtect, &oldProtect);
     return hook32_size;
+}
+
+size_t peconv::redirect_to_local(void *ptr, void* new_function_ptr, PatchBackup* backup)
+{
+#ifdef _WIN64
+    return peconv::redirect_to_local64(ptr, (ULONGLONG)new_function_ptr, backup);
+#else
+    return peconv::redirect_to_local32(ptr, (DWORD)new_function_ptr, backup);
+#endif
 }
 
 inline long long int get_jmp_delta(ULONGLONG currVA, int instrLen, ULONGLONG destVA)


### PR DESCRIPTION
…w to overwrite NTDLL's functions.